### PR TITLE
missing parts have been added

### DIFF
--- a/src/main/java/tr/com/burakgul/profileapi/config/ProfileSecurityConfig.java
+++ b/src/main/java/tr/com/burakgul/profileapi/config/ProfileSecurityConfig.java
@@ -41,7 +41,7 @@ public class ProfileSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        String[] whiteList = {"/auth/**","/healthCheck","/swagger-resources/**", "/swagger-ui.html", "/v2/api-docs", "/webjars/**"};
+        String[] whiteList = {"/auth/**","/healthcheck","/swagger-resources/**", "/swagger-ui.html", "/v2/api-docs", "/webjars/**"};
 
         http.csrf().disable()
                 .authorizeRequests().antMatchers(whiteList).permitAll().anyRequest().authenticated()

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/EducationController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/EducationController.java
@@ -25,7 +25,7 @@ public class EducationController {
         return ResponseEntity.ok(this.educationService.save(educationRequest));
     }
 
-    @PutMapping("/educationId")
+    @PutMapping("/{educationId}")
     public ResponseEntity<EducationDTO> update(@RequestBody EducationDTO educationRequest, @PathVariable Long educationId) {
         return ResponseEntity.ok(this.educationService.update(educationRequest, educationId));
     }

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/EducationController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/EducationController.java
@@ -1,5 +1,33 @@
 package tr.com.burakgul.profileapi.controller.main;
 
-//TODO
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tr.com.burakgul.profileapi.model.dto.main.EducationDTO;
+import tr.com.burakgul.profileapi.model.entity.main.Education;
+import tr.com.burakgul.profileapi.service.main.EducationService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/education")
+@RequiredArgsConstructor
 public class EducationController {
+    private final EducationService educationService;
+
+    @GetMapping
+    public ResponseEntity<List<EducationDTO>> findAll() {
+        return ResponseEntity.ok(this.educationService.findAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<EducationDTO> save(@RequestBody EducationDTO educationRequest) {
+        return ResponseEntity.ok(this.educationService.save(educationRequest));
+    }
+
+    @PutMapping("/educationId")
+    public ResponseEntity<EducationDTO> update(@RequestBody EducationDTO educationRequest, @PathVariable Long educationId) {
+        return ResponseEntity.ok(this.educationService.update(educationRequest, educationId));
+    }
+
 }

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/HeaderController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/HeaderController.java
@@ -20,7 +20,7 @@ public class HeaderController {
     private final HeaderService headerService;
 
     @PostMapping
-    public ResponseEntity<Object> save(@RequestBody HeaderRequest headerRequest){
+    public ResponseEntity<HeaderResponse> save(@RequestBody HeaderRequest headerRequest){
         return ResponseEntity.ok(this.headerService.save(headerRequest));
     }
 

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/ProjectSectionController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/ProjectSectionController.java
@@ -21,8 +21,8 @@ public class ProjectSectionController {
     private final ProjectSectionService projectSectionService;
 
     @GetMapping
-    public ResponseEntity<ProjectSectionDTO> find(){
-        return ResponseEntity.ok(this.projectSectionService.find());
+    public ResponseEntity<ProjectSectionDTO> findProjectSection(){
+        return ResponseEntity.ok(this.projectSectionService.findProjectSection());
     }
 
     @PostMapping

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/ResumeController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/ResumeController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tr.com.burakgul.profileapi.model.dto.main.ResumeDTO;
 import tr.com.burakgul.profileapi.service.main.ResumeService;
@@ -22,17 +21,17 @@ public class ResumeController {
     private final ResumeService resumeService;
 
     @GetMapping
-    public ResponseEntity<ResumeDTO> find(){
-        return ResponseEntity.ok(this.resumeService.find());
+    public ResponseEntity<ResumeDTO> findResume() {
+        return ResponseEntity.ok(this.resumeService.findResume());
     }
 
     @PutMapping
-    public ResponseEntity<ResumeDTO> update(@RequestBody ResumeDTO resume, @RequestParam Long id){
-        return ResponseEntity.ok(this.resumeService.update(resume, id));
+    public ResponseEntity<ResumeDTO> update(@RequestBody ResumeDTO resume) {
+        return ResponseEntity.ok(this.resumeService.update(resume));
     }
 
     @PostMapping
-    public ResponseEntity<ResumeDTO> save(@RequestBody ResumeDTO resumeDTO){
+    public ResponseEntity<ResumeDTO> save(@RequestBody ResumeDTO resumeDTO) {
         return ResponseEntity.created(URI.create("/resume"))
                 .body(this.resumeService.save(resumeDTO));
     }

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/SkillController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/SkillController.java
@@ -1,0 +1,32 @@
+package tr.com.burakgul.profileapi.controller.main;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tr.com.burakgul.profileapi.model.dto.main.SkillDTO;
+import tr.com.burakgul.profileapi.service.main.SkillService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/skill")
+@RequiredArgsConstructor
+public class SkillController {
+    private final SkillService skillService;
+
+
+    @GetMapping
+    public ResponseEntity<List<SkillDTO>> findAll() {
+        return ResponseEntity.ok(this.skillService.findAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<SkillDTO> save(@RequestBody SkillDTO skillRequest) {
+        return ResponseEntity.ok(this.skillService.save(skillRequest));
+    }
+
+    @PutMapping("/skillId")
+    public ResponseEntity<SkillDTO> update(@RequestBody SkillDTO skillRequest, @PathVariable Long skillId) {
+        return ResponseEntity.ok(this.skillService.update(skillRequest, skillId));
+    }
+}

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/SkillController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/SkillController.java
@@ -25,7 +25,7 @@ public class SkillController {
         return ResponseEntity.ok(this.skillService.save(skillRequest));
     }
 
-    @PutMapping("/skillId")
+    @PutMapping("/{skillId}")
     public ResponseEntity<SkillDTO> update(@RequestBody SkillDTO skillRequest, @PathVariable Long skillId) {
         return ResponseEntity.ok(this.skillService.update(skillRequest, skillId));
     }

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/SkillSectionController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/SkillSectionController.java
@@ -1,5 +1,31 @@
 package tr.com.burakgul.profileapi.controller.main;
 
-//TODO
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tr.com.burakgul.profileapi.model.dto.main.SkillSectionDTO;
+import tr.com.burakgul.profileapi.service.main.SkillSectionService;
+
+@RestController
+@RequestMapping("/skillSection")
+@RequiredArgsConstructor
+
 public class SkillSectionController {
+    public final SkillSectionService skillSectionService;
+
+    @GetMapping
+    public ResponseEntity<SkillSectionDTO> findSkillSection() {
+        return ResponseEntity.ok(this.skillSectionService.findSkillSection());
+    }
+
+    @PostMapping
+    public ResponseEntity<SkillSectionDTO> save(@RequestBody SkillSectionDTO skillSectionRequest) {
+        return ResponseEntity.ok(this.skillSectionService.save(skillSectionRequest));
+    }
+
+    @PutMapping
+    public ResponseEntity<SkillSectionDTO> update(@RequestBody SkillSectionDTO skillSectionRequest) {
+        return ResponseEntity.ok(this.skillSectionService.update(skillSectionRequest));
+    }
+
 }

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/WorkExperienceController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/WorkExperienceController.java
@@ -22,7 +22,7 @@ public class WorkExperienceController {
         return ResponseEntity.ok(this.workExperienceService.save(workExperienceRequest));
     }
 
-    @PutMapping("/workExperienceId")
+    @PutMapping("/{workExperienceId}")
     public ResponseEntity<WorkExperienceDTO> update(@RequestBody WorkExperienceDTO workExperienceRequest, @PathVariable Long workExperienceId){
         return ResponseEntity.ok(this.workExperienceService.update(workExperienceRequest, workExperienceId));
     }

--- a/src/main/java/tr/com/burakgul/profileapi/controller/main/WorkExperienceController.java
+++ b/src/main/java/tr/com/burakgul/profileapi/controller/main/WorkExperienceController.java
@@ -3,15 +3,12 @@ package tr.com.burakgul.profileapi.controller.main;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.jdbc.Work;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import tr.com.burakgul.profileapi.model.dto.main.WorkExperienceDTO;
 import tr.com.burakgul.profileapi.model.entity.main.WorkExperience;
 import tr.com.burakgul.profileapi.service.main.WorkExperienceService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/workExperience")
@@ -28,5 +25,10 @@ public class WorkExperienceController {
     @PutMapping("/workExperienceId")
     public ResponseEntity<WorkExperienceDTO> update(@RequestBody WorkExperienceDTO workExperienceRequest, @PathVariable Long workExperienceId){
         return ResponseEntity.ok(this.workExperienceService.update(workExperienceRequest, workExperienceId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<WorkExperienceDTO>> findAll(){
+        return ResponseEntity.ok(this.workExperienceService.findAll());
     }
 }

--- a/src/main/java/tr/com/burakgul/profileapi/model/dto/UserRequest.java
+++ b/src/main/java/tr/com/burakgul/profileapi/model/dto/UserRequest.java
@@ -1,12 +1,12 @@
 package tr.com.burakgul.profileapi.model.dto;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class UserRequest {
     private String username;
 

--- a/src/main/java/tr/com/burakgul/profileapi/model/dto/main/ContactResponse.java
+++ b/src/main/java/tr/com/burakgul/profileapi/model/dto/main/ContactResponse.java
@@ -1,0 +1,5 @@
+package tr.com.burakgul.profileapi.model.dto.main;
+
+public class ContactResponse extends ContactRequest{
+
+}

--- a/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillDTO.java
+++ b/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillDTO.java
@@ -1,12 +1,12 @@
 package tr.com.burakgul.profileapi.model.dto.main;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class SkillDTO {
     private Integer progress;
     private String name;

--- a/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillDTO.java
+++ b/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillDTO.java
@@ -1,0 +1,13 @@
+package tr.com.burakgul.profileapi.model.dto.main;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class SkillDTO {
+    private Integer progress;
+    private String name;
+}

--- a/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillSectionDTO.java
+++ b/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillSectionDTO.java
@@ -1,14 +1,14 @@
 package tr.com.burakgul.profileapi.model.dto.main;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
 
 @Getter
 @Setter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class SkillSectionDTO {
     private String title;
     private List<SkillDTO> skills;

--- a/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillSectionDTO.java
+++ b/src/main/java/tr/com/burakgul/profileapi/model/dto/main/SkillSectionDTO.java
@@ -1,0 +1,15 @@
+package tr.com.burakgul.profileapi.model.dto.main;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class SkillSectionDTO {
+    private String title;
+    private List<SkillDTO> skills;
+}

--- a/src/main/java/tr/com/burakgul/profileapi/repository/main/HeaderRepository.java
+++ b/src/main/java/tr/com/burakgul/profileapi/repository/main/HeaderRepository.java
@@ -8,6 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface HeaderRepository extends JpaRepository<Header,Long> {
-
     Optional<Header> findTopByOrderByIdDesc();
 }

--- a/src/main/java/tr/com/burakgul/profileapi/repository/main/ProjectSectionRepository.java
+++ b/src/main/java/tr/com/burakgul/profileapi/repository/main/ProjectSectionRepository.java
@@ -3,5 +3,8 @@ package tr.com.burakgul.profileapi.repository.main;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tr.com.burakgul.profileapi.model.entity.main.ProjectSection;
 
+import java.util.Optional;
+
 public interface ProjectSectionRepository extends JpaRepository<ProjectSection,Long> {
+    Optional<ProjectSection> findTopByOrderByIdDesc();
 }

--- a/src/main/java/tr/com/burakgul/profileapi/repository/main/SkillSectionRepository.java
+++ b/src/main/java/tr/com/burakgul/profileapi/repository/main/SkillSectionRepository.java
@@ -3,5 +3,8 @@ package tr.com.burakgul.profileapi.repository.main;
 import org.springframework.data.jpa.repository.JpaRepository;
 import tr.com.burakgul.profileapi.model.entity.main.SkillSection;
 
+import java.util.Optional;
+
 public interface SkillSectionRepository extends JpaRepository<SkillSection,Long> {
+    Optional<SkillSection> findTopByOrderByIdDesc();
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/UserDetailService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/UserDetailService.java
@@ -34,5 +34,4 @@ public class UserDetailService implements UserDetailsService {
         User savedUser = this.userRepository.save(user);
         return this.dtoMapper.mapModel(savedUser, UserResponse.class);
     }
-
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/ContactService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/ContactService.java
@@ -2,7 +2,13 @@ package tr.com.burakgul.profileapi.service.main;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.model.dto.main.ContactRequest;
+import tr.com.burakgul.profileapi.model.dto.main.ContactResponse;
+import tr.com.burakgul.profileapi.model.dto.main.WorkExperienceDTO;
 import tr.com.burakgul.profileapi.model.entity.main.Contact;
+import tr.com.burakgul.profileapi.model.entity.main.WorkExperience;
 import tr.com.burakgul.profileapi.repository.main.ContactRepository;
 
 import java.util.List;
@@ -12,8 +18,13 @@ import java.util.List;
 public class ContactService {
 
     private final ContactRepository contactRepository;
+    private final DTOMapper dtoMapper;
 
-    public List<Contact> saveAll(List<Contact> contacts){
-        return this.contactRepository.saveAll(contacts);
+    @Transactional
+    public List<ContactResponse> saveAll(List<ContactRequest> contactRequest){
+        List<Contact> upToDateContacts = this.dtoMapper.mapListModel(contactRequest, Contact.class);
+        List<Contact> savedContacts = this.contactRepository.saveAll(upToDateContacts);
+        return this.dtoMapper.mapListModel(savedContacts, ContactResponse.class);
     }
 }
+//TODO findAll, save ve update methodlari eklenebilir hatta delete methodu

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/EducationService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/EducationService.java
@@ -1,16 +1,23 @@
 package tr.com.burakgul.profileapi.service.main;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.core.util.ObjectUpdaterUtil;
 import tr.com.burakgul.profileapi.model.dto.main.EducationDTO;
-import tr.com.burakgul.profileapi.repository.main.EducationRepository;
+import tr.com.burakgul.profileapi.model.dto.main.WorkExperienceDTO;
 import tr.com.burakgul.profileapi.model.entity.main.Education;
+import tr.com.burakgul.profileapi.model.entity.main.WorkExperience;
+import tr.com.burakgul.profileapi.repository.main.EducationRepository;
 
-
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+//TODO
 @Service
 @RequiredArgsConstructor
 public class EducationService {
@@ -18,23 +25,41 @@ public class EducationService {
     private final EducationRepository educationRepository;
     private final DTOMapper dtoMapper;
 
-    public EducationDTO save(EducationDTO educationRequest){
+    @Transactional(readOnly = true)
+    public List<EducationDTO> findAll() {
+        List<Education> educationList = this.educationRepository.findAll();
+        if(educationList.size() != 0){
+            return this.dtoMapper.mapListModel(educationList, EducationDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Herhangi bir education bulunamadi.");
+        }
+    }
+
+    @Transactional
+    public EducationDTO save(EducationDTO educationRequest) {
         Education upToDateEducation = this.dtoMapper.mapModel(educationRequest, Education.class);
         Education education = this.educationRepository.save(upToDateEducation);
         return this.dtoMapper.mapModel(education, EducationDTO.class);
     }
 
-    public List<EducationDTO> saveAll(List<EducationDTO> educationsRequest){
-        List<Education> upToDateEducations = this.dtoMapper.mapListModel(educationsRequest, Education.class);
-        List<Education> educations = this.educationRepository.saveAll(upToDateEducations);
-        return this.dtoMapper.mapListModel(educations, EducationDTO.class);
+    @Transactional
+    public List<EducationDTO> saveAll(List<EducationDTO> educationRequest) {
+        List<Education> upToDateEducations = this.dtoMapper.mapListModel(educationRequest, Education.class);
+        List<Education> savedEducations = this.educationRepository.saveAll(upToDateEducations);
+        return this.dtoMapper.mapListModel(savedEducations, EducationDTO.class);
     }
 
-    public EducationDTO update(EducationDTO education){
-        return education;
-    }
-
-    public List<EducationDTO> findAll(){
-        return new ArrayList<>();
+    @Transactional
+    public EducationDTO update(EducationDTO educationRequest, Long educationId) {
+        Optional<Education> optionalEducation = this.educationRepository.findById(educationId);
+        if (optionalEducation.isPresent()) {
+            Education currentEducation = optionalEducation.get();
+            Education upToDateEducation = this.dtoMapper.mapModel(educationRequest, Education.class);
+            ObjectUpdaterUtil.updateObject(currentEducation, upToDateEducation, Arrays.asList("id"));
+            Education savedEducation = this.educationRepository.save(currentEducation);
+            return this.dtoMapper.mapModel(savedEducation, EducationDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bu id ile Education bulunamadi.");
+        }
     }
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/ImageService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/ImageService.java
@@ -2,6 +2,9 @@ package tr.com.burakgul.profileapi.service.main;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.model.dto.ImageDTO;
 import tr.com.burakgul.profileapi.model.entity.Image;
 import tr.com.burakgul.profileapi.repository.main.ImageRepository;
 
@@ -10,8 +13,15 @@ import tr.com.burakgul.profileapi.repository.main.ImageRepository;
 public class ImageService {
 
     private final ImageRepository imageRepository;
+    private final DTOMapper dtoMapper;
 
-    public Image save(Image image){
-        return this.imageRepository.save(image);
+    @Transactional
+    public ImageDTO save(ImageDTO imageRequest){
+        Image upToDateImage = this.dtoMapper.mapModel(imageRequest, Image.class);
+        Image savedImage = this.imageRepository.save(upToDateImage);
+        return this.dtoMapper.mapModel(savedImage, ImageDTO.class);
     }
+
+    //TODO find ve update methodlari eklenebilir hatta delete methodu
+
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/ProjectSectionService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/ProjectSectionService.java
@@ -1,26 +1,67 @@
 package tr.com.burakgul.profileapi.service.main;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.core.util.ObjectUpdaterUtil;
+import tr.com.burakgul.profileapi.model.dto.main.ProjectDTO;
 import tr.com.burakgul.profileapi.model.dto.main.ProjectSectionDTO;
+import tr.com.burakgul.profileapi.model.entity.main.Project;
+import tr.com.burakgul.profileapi.model.entity.main.ProjectSection;
 import tr.com.burakgul.profileapi.repository.main.ProjectSectionRepository;
 
-//TODO
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectSectionService {
 
     private final ProjectSectionRepository projectSectionRepository;
+    private final ProjectService projectService;
+    private final DTOMapper dtoMapper;
 
-    public ProjectSectionDTO find() {
-        return new ProjectSectionDTO();
+    @Transactional(readOnly = true)
+    public ProjectSectionDTO findProjectSection() {
+        ProjectSection currentProjectSection = this.projectSectionRepository.findTopByOrderByIdDesc()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Project Section bulunamadi."));
+        return this.dtoMapper.mapModel(currentProjectSection, ProjectSectionDTO.class);
     }
 
-    public ProjectSectionDTO save(ProjectSectionDTO projectSectionDTO) {
-        return projectSectionDTO;
+    @Transactional
+    public ProjectSectionDTO save(ProjectSectionDTO projectSectionRequest) {
+        ProjectSection projectSectionToBeSavedOrUpdated = this.dtoMapper.mapModel(projectSectionRequest, ProjectSection.class);
+        this.setProjectSectionWithRelations(projectSectionToBeSavedOrUpdated, projectSectionRequest);
+        ProjectSection savedProjectSection = this.projectSectionRepository.save(projectSectionToBeSavedOrUpdated);
+        return this.dtoMapper.mapModel(savedProjectSection, ProjectSectionDTO.class);
     }
 
-    public ProjectSectionDTO update(ProjectSectionDTO projectSectionDTO) {
-        return projectSectionDTO;
+    @Transactional
+    public ProjectSectionDTO update(ProjectSectionDTO projectSectionRequest) {
+        Optional<ProjectSection> projectSectionOptional = this.projectSectionRepository.findTopByOrderByIdDesc();
+        if (projectSectionOptional.isPresent()) {
+            ProjectSection projectSectionToBeSavedOrUpdated = projectSectionOptional.get();
+            this.updateProjectSectionWithRelations(projectSectionToBeSavedOrUpdated, projectSectionRequest);
+            ProjectSection savedProjectSection = this.projectSectionRepository.save(projectSectionToBeSavedOrUpdated);
+            return this.dtoMapper.mapModel(savedProjectSection, ProjectSectionDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "ProjectSection bulunamadi!");
+        }
+    }
+
+    private void updateProjectSectionWithRelations(ProjectSection projectSectionToBeSavedOrUpdated, ProjectSectionDTO projectSectionRequest) {
+        ProjectSection upToDateProjectSection = this.dtoMapper.mapModel(projectSectionRequest, ProjectSection.class);
+        ObjectUpdaterUtil.updateObject(projectSectionToBeSavedOrUpdated, upToDateProjectSection, Arrays.asList("id", "projects"));
+        this.setProjectSectionWithRelations(projectSectionToBeSavedOrUpdated, projectSectionRequest);
+    }
+
+    private void setProjectSectionWithRelations(ProjectSection projectSectionToBeSavedOrUpdated, ProjectSectionDTO projectSectionRequest){
+        List<ProjectDTO> savedProjects = this.projectService.saveAll(projectSectionRequest.getProjects());
+        List<Project> mappedProjectsToSetProjectSection = this.dtoMapper.mapListModel(savedProjects, Project.class);
+        projectSectionToBeSavedOrUpdated.setProjects(mappedProjectsToSetProjectSection);
     }
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/ProjectService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/ProjectService.java
@@ -2,12 +2,27 @@ package tr.com.burakgul.profileapi.service.main;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.model.dto.main.ProjectDTO;
+import tr.com.burakgul.profileapi.model.entity.main.Project;
 import tr.com.burakgul.profileapi.repository.main.ProjectRepository;
 
-//TODO
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final DTOMapper dtoMapper;
+
+    @Transactional
+    public List<ProjectDTO> saveAll(List<ProjectDTO> projectsRequest){
+        List<Project> upToDateProjects = this.dtoMapper.mapListModel(projectsRequest, Project.class);
+        List<Project> savedProjects = this.projectRepository.saveAll(upToDateProjects);
+        return this.dtoMapper.mapListModel(savedProjects, ProjectDTO.class);
+    }
 }
+//TODO findAll, save ve update methodlari eklenebilir hatta delete methodu
+

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/SkillSectionService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/SkillSectionService.java
@@ -1,5 +1,69 @@
 package tr.com.burakgul.profileapi.service.main;
 
-//TODO
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.core.util.ObjectUpdaterUtil;
+import tr.com.burakgul.profileapi.model.dto.main.SkillDTO;
+import tr.com.burakgul.profileapi.model.dto.main.SkillSectionDTO;
+import tr.com.burakgul.profileapi.model.entity.main.Skill;
+import tr.com.burakgul.profileapi.model.entity.main.SkillSection;
+import tr.com.burakgul.profileapi.repository.main.SkillSectionRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
 public class SkillSectionService {
+    private final SkillSectionRepository skillSectionRepository;
+    private final SkillService skillService;
+    private final DTOMapper dtoMapper;
+
+    @Transactional(readOnly = true)
+    public SkillSectionDTO findSkillSection() {
+        Optional<SkillSection> currentSkillSection = this.skillSectionRepository.findTopByOrderByIdDesc();
+        if (currentSkillSection.isPresent()) {
+            return this.dtoMapper.mapModel(currentSkillSection, SkillSectionDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Skill Section bulunamadi.");
+        }
+    }
+
+    @Transactional
+    public SkillSectionDTO save(SkillSectionDTO skillSectionRequest) {
+        SkillSection skillSectionToBeSavedOrUpdated = this.dtoMapper.mapModel(skillSectionRequest, SkillSection.class);
+        this.setSkillSectionWithRelations(skillSectionToBeSavedOrUpdated, skillSectionRequest);
+        SkillSection savedSkillSection = this.skillSectionRepository.save(skillSectionToBeSavedOrUpdated);
+        return this.dtoMapper.mapModel(savedSkillSection, SkillSectionDTO.class);
+    }
+
+    @Transactional
+    public SkillSectionDTO update(SkillSectionDTO skillSectionRequest) {
+        Optional<SkillSection> skillSectionOptional = this.skillSectionRepository.findTopByOrderByIdDesc();
+        if (skillSectionOptional.isPresent()) {
+            SkillSection skillSectionToBeSavedOrUpdated = skillSectionOptional.get();
+            this.updateSkillSectionWithRelations(skillSectionToBeSavedOrUpdated, skillSectionRequest);
+            SkillSection savedSkillSection = this.skillSectionRepository.save(skillSectionToBeSavedOrUpdated);
+            return this.dtoMapper.mapModel(savedSkillSection, SkillSectionDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "SkillSection bulunamadi!");
+        }
+    }
+
+    private void updateSkillSectionWithRelations(SkillSection skillSectionToBeSavedOrUpdated, SkillSectionDTO skillSectionRequest) {
+        SkillSection upToDateSkillSection = this.dtoMapper.mapModel(skillSectionRequest, SkillSection.class);
+        ObjectUpdaterUtil.updateObject(skillSectionToBeSavedOrUpdated, upToDateSkillSection, Arrays.asList("id", "skills"));
+        this.setSkillSectionWithRelations(skillSectionToBeSavedOrUpdated, skillSectionRequest);
+    }
+
+    private void setSkillSectionWithRelations(SkillSection skillSectionToBeSavedOrUpdated, SkillSectionDTO skillSectionRequest){
+        List<SkillDTO> savedSkills = this.skillService.saveAll(skillSectionRequest.getSkills());
+        List<Skill> mappedSkillsToSetSkillSection = this.dtoMapper.mapListModel(savedSkills, Skill.class);
+        skillSectionToBeSavedOrUpdated.setSkills(mappedSkillsToSetSkillSection);
+    }
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/SkillService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/SkillService.java
@@ -1,5 +1,62 @@
 package tr.com.burakgul.profileapi.service.main;
 
-//TODO
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.core.util.ObjectUpdaterUtil;
+import tr.com.burakgul.profileapi.model.dto.main.ContactResponse;
+import tr.com.burakgul.profileapi.model.dto.main.SkillDTO;
+import tr.com.burakgul.profileapi.model.entity.main.Contact;
+import tr.com.burakgul.profileapi.model.entity.main.Skill;
+import tr.com.burakgul.profileapi.repository.main.SkillRepository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
 public class SkillService {
+    private final SkillRepository skillRepository;
+    private final DTOMapper dtoMapper;
+    @Transactional(readOnly = true)
+    public List<SkillDTO> findAll() {
+        List<Skill> skillList = this.skillRepository.findAll();
+        if(skillList.size() != 0){
+            return this.dtoMapper.mapListModel(skillList, SkillDTO.class);
+        }else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Herhangi bir Skill bulunamadi.");
+        }
+    }
+
+    @Transactional
+    public SkillDTO save(SkillDTO skillRequest) {
+        Skill upToDateSkill = this.dtoMapper.mapModel(skillRequest, Skill.class);
+        Skill savedSkill = this.skillRepository.save(upToDateSkill);
+        return this.dtoMapper.mapModel(savedSkill, SkillDTO.class);
+    }
+
+    @Transactional
+    public List<SkillDTO> saveAll(List<SkillDTO> skillRequest) {
+        List<Skill> upToDateSkills = this.dtoMapper.mapListModel(skillRequest, Skill.class);
+        List<Skill> savedSkills = this.skillRepository.saveAll(upToDateSkills);
+        return this.dtoMapper.mapListModel(savedSkills, SkillDTO.class);
+    }
+
+    @Transactional
+    public SkillDTO update(SkillDTO skillRequest, Long skillId) {
+        Optional<Skill> skillOptional = skillRepository.findById(skillId);
+        if(skillOptional.isPresent()){
+            Skill currentSkill = skillOptional.get();
+            Skill upToDateSkill = this.dtoMapper.mapModel(skillRequest, Skill.class);
+            ObjectUpdaterUtil.updateObject(currentSkill, upToDateSkill, Arrays.asList("id"));
+            Skill savedSkill = this.skillRepository.save(currentSkill);
+            return this.dtoMapper.mapModel(savedSkill, SkillDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bu id ile herhangi bir Skill bulunamadi.");
+        }
+    }
 }

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/SocialMediaService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/SocialMediaService.java
@@ -2,6 +2,9 @@ package tr.com.burakgul.profileapi.service.main;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tr.com.burakgul.profileapi.core.helper.DTOMapper;
+import tr.com.burakgul.profileapi.model.dto.main.SocialMediaDTO;
 import tr.com.burakgul.profileapi.model.entity.main.SocialMedia;
 import tr.com.burakgul.profileapi.repository.main.SocialMediaRepository;
 
@@ -12,8 +15,14 @@ import java.util.List;
 public class SocialMediaService {
 
     private final SocialMediaRepository socialMediaRepository;
+    private final DTOMapper dtoMapper;
 
-    public List<SocialMedia> saveAll(List<SocialMedia> socialMedia){
-        return this.socialMediaRepository.saveAll(socialMedia);
+    @Transactional
+    public List<SocialMediaDTO> saveAll(List<SocialMediaDTO> socialMediasRequest){
+        List<SocialMedia> upToDateSocialMedias = this.dtoMapper.mapListModel(socialMediasRequest, SocialMedia.class);
+        List<SocialMedia> savedSocialMedias = this.socialMediaRepository.saveAll(upToDateSocialMedias);
+        return this.dtoMapper.mapListModel(savedSocialMedias, SocialMediaDTO.class);
     }
 }
+//TODO findAll, save ve update methodlari eklenebilir hatta delete methodu
+

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/WorkExperienceService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/WorkExperienceService.java
@@ -25,10 +25,10 @@ public class WorkExperienceService {
     @Transactional(readOnly = true)
     public List<WorkExperienceDTO> findAll() {
         List<WorkExperience> workExperienceList = this.workExperienceRepository.findAll();
-        if (workExperienceList.size() != 0) {
-            return this.dtoMapper.mapListModel(workExperienceList, WorkExperienceDTO.class);
-        } else {
+        if (workExperienceList.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Herhangi bir Work Experience bulunamadi.");
+        } else {
+            return this.dtoMapper.mapListModel(workExperienceList, WorkExperienceDTO.class);
         }
     }
 

--- a/src/main/java/tr/com/burakgul/profileapi/service/main/WorkExperienceService.java
+++ b/src/main/java/tr/com/burakgul/profileapi/service/main/WorkExperienceService.java
@@ -3,6 +3,7 @@ package tr.com.burakgul.profileapi.service.main;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import tr.com.burakgul.profileapi.core.helper.DTOMapper;
 import tr.com.burakgul.profileapi.core.util.ObjectUpdaterUtil;
@@ -10,7 +11,6 @@ import tr.com.burakgul.profileapi.model.dto.main.WorkExperienceDTO;
 import tr.com.burakgul.profileapi.model.entity.main.WorkExperience;
 import tr.com.burakgul.profileapi.repository.main.WorkExperienceRepository;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -22,32 +22,43 @@ public class WorkExperienceService {
     private final WorkExperienceRepository workExperienceRepository;
     private final DTOMapper dtoMapper;
 
+    @Transactional(readOnly = true)
+    public List<WorkExperienceDTO> findAll() {
+        List<WorkExperience> workExperienceList = this.workExperienceRepository.findAll();
+        if (workExperienceList.size() != 0) {
+            return this.dtoMapper.mapListModel(workExperienceList, WorkExperienceDTO.class);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Herhangi bir Work Experience bulunamadi.");
+        }
+    }
+
+    @Transactional
     public WorkExperienceDTO save(WorkExperienceDTO workExperienceRequest) {
         WorkExperience upToDateWorkExperience = this.dtoMapper.mapModel(workExperienceRequest, WorkExperience.class);
         WorkExperience savedWorkExperience = this.workExperienceRepository.save(upToDateWorkExperience);
         return this.dtoMapper.mapModel(savedWorkExperience, WorkExperienceDTO.class);
     }
 
+    @Transactional
     public List<WorkExperienceDTO> saveAll(List<WorkExperienceDTO> workExperiencesRequest) {
         List<WorkExperience> upToDateWorkExperiences = this.dtoMapper.mapListModel(workExperiencesRequest, WorkExperience.class);
-        List<WorkExperience> workExperiences = this.workExperienceRepository.saveAll(upToDateWorkExperiences);
-        return dtoMapper.mapListModel(workExperiences, WorkExperienceDTO.class);
+        List<WorkExperience> savedWorkExperiences = this.workExperienceRepository.saveAll(upToDateWorkExperiences);
+        return this.dtoMapper.mapListModel(savedWorkExperiences, WorkExperienceDTO.class);
     }
 
+
+    @Transactional
     public WorkExperienceDTO update(WorkExperienceDTO workExperienceRequest, Long workExperienceId) {
         Optional<WorkExperience> workExperienceOptional = this.workExperienceRepository.findById(workExperienceId);
         if (workExperienceOptional.isPresent()) {
             WorkExperience currentWorkExperience = workExperienceOptional.get();
-            ObjectUpdaterUtil.updateObject(currentWorkExperience, workExperienceRequest, Arrays.asList("id"));
+            WorkExperience upToDateWorkExperience = this.dtoMapper.mapModel(workExperienceRequest, WorkExperience.class);
+            ObjectUpdaterUtil.updateObject(currentWorkExperience, upToDateWorkExperience, Arrays.asList("id"));
             WorkExperience savedCurrentWorkExperience = this.workExperienceRepository.save(currentWorkExperience);
             return this.dtoMapper.mapModel(savedCurrentWorkExperience, WorkExperienceDTO.class);
         } else {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bu id ile work experience bulunamadı.");
         }
-    }
-
-    public List<WorkExperienceDTO> findAll() {
-        return new ArrayList<>();
     }
 
 }


### PR DESCRIPTION
- Each service calls its own repo now. If we need to call another repo in a service (like calling education repo in resume service), then we first call the relevant service from the current service (like calling education service from resume service) and then we call the education repo from there. If we need a new business logic in the future then it will be easier to add it now. We used to call subtable's repo directly from the main table service (like calling education repo from resume service) and in this case we were omitting the education service so it was not possible to add any business logic to education service in case of needed.
- All the services have been updated so that all of them takes and returns only DTO, not entity itself.